### PR TITLE
Added exception handling for video read bucket_sampler.py

### DIFF
--- a/easyanimate/data/bucket_sampler.py
+++ b/easyanimate/data/bucket_sampler.py
@@ -243,6 +243,9 @@ class AspectRatioBatchSampler(BatchSampler):
                         videoid, name, page_dir = video_dict['videoid'], video_dict['name'], video_dict['page_dir']
                         video_dir = os.path.join(self.video_folder, f"{videoid}.mp4")
                     cap = cv2.VideoCapture(video_dir)
+                    if not cap.isOpened():
+                        print(f"Open video {video_dir} is error! ")
+                        continue
 
                     # 获取视频尺寸
                     width  = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))   # 浮点数转换为整数
@@ -354,6 +357,9 @@ class AspectRatioBatchImageVideoSampler(BatchSampler):
                         else:
                             video_dir = os.path.join(self.train_folder, video_id)
                         cap = cv2.VideoCapture(video_dir)
+                        if not cap.isOpened():
+                            print(f"Open video {video_dir} is error! ")
+                            continue
 
                         # 获取视频尺寸
                         width  = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))   # 浮点数转换为整数


### PR DESCRIPTION
There seems to be a bug here.
If `video_dir` fails to be read, an exception caught by try will not be thrown, resulting in `width` and `height` is 0, and subsequent division operations will report an error.